### PR TITLE
feat: add strip feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-tag-swc-plugin",
-  "version": "0.1.3",
+  "version": "0.1.4-0",
   "description": "SWC plugin to expand gql tags at build time",
   "author": "rishabh3112 <rishabh31121999@gmail.com>",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-tag-swc-plugin",
-  "version": "0.1.4-0",
+  "version": "0.1.4-1",
   "description": "SWC plugin to expand gql tags at build time",
   "author": "rishabh3112 <rishabh31121999@gmail.com>",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-tag-swc-plugin",
-  "version": "0.1.4-1",
+  "version": "0.1.4",
   "description": "SWC plugin to expand gql tags at build time",
   "author": "rishabh3112 <rishabh31121999@gmail.com>",
   "license": "ISC",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ use graphql_tag::structs::{GraphQLTagConfig, TransformVisitor};
 pub struct Config {
     pub import_sources: Option<Vec<String>>,
     pub gql_tag_identifiers: Option<Vec<String>>,
+    pub strip: Option<bool>,
 }
 
 #[plugin_transform]
@@ -19,6 +20,7 @@ pub fn process_transform(program: Program, data: TransformPluginProgramMetadata)
     let default_config = GraphQLTagConfig {
         import_sources: vec!["@apollo/client".to_string(), "graphql-tag".into()],
         gql_tag_identifiers: vec!["gql".to_string()],
+        strip: false,
     };
 
     let config = match data.get_transform_plugin_config() {
@@ -32,6 +34,7 @@ pub fn process_transform(program: Program, data: TransformPluginProgramMetadata)
                     gql_tag_identifiers: config
                         .gql_tag_identifiers
                         .unwrap_or(default_config.gql_tag_identifiers),
+                    strip: config.strip.unwrap_or(false),
                 },
                 Err(_) => {
                     println!("Got invalid config for graphql-tag-swc-plugin, using default config instead");

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -28,6 +28,7 @@ fn graphql_tag_fixture(input: PathBuf) {
             as_folder(TransformVisitor::new(GraphQLTagConfig {
                 import_sources: vec!["@apollo/client".to_string(), "graphql-tag".into()],
                 gql_tag_identifiers: vec!["gql".to_string()],
+                strip: false,
             }))
         },
         &input,

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -28,7 +28,7 @@ fn graphql_tag_fixture(input: PathBuf) {
             as_folder(TransformVisitor::new(GraphQLTagConfig {
                 import_sources: vec!["@apollo/client".to_string(), "graphql-tag".into()],
                 gql_tag_identifiers: vec!["gql".to_string()],
-                strip: false,
+                strip: true,
             }))
         },
         &input,

--- a/tests/fixtures/definations/fragment/output.js
+++ b/tests/fixtures/definations/fragment/output.js
@@ -43,9 +43,9 @@ const FRAGMENT = {
     ],
     "loc": {
         "start": 0,
-        "end": 57,
+        "end": 40,
         "source": {
-            "body": "\n  fragment TestFragment on Entity {\n    id\n    name\n  }\n"
+            "body": "fragment TestFragment on Entity{id name}"
         }
     }
 };

--- a/tests/fixtures/definations/operation/mutation/output.js
+++ b/tests/fixtures/definations/operation/mutation/output.js
@@ -63,9 +63,9 @@ const MUTATION = {
     ],
     "loc": {
         "start": 0,
-        "end": 82,
+        "end": 67,
         "source": {
-            "body": "\n  mutation testMutation($entity: String) {\n    updateEntity(entity: $entity)\n  }\n"
+            "body": "mutation testMutation($entity:String){updateEntity(entity:$entity)}"
         }
     }
 };

--- a/tests/fixtures/definations/operation/query/output.js
+++ b/tests/fixtures/definations/operation/query/output.js
@@ -52,9 +52,9 @@ const QUERY = {
     ],
     "loc": {
         "start": 0,
-        "end": 67,
+        "end": 35,
         "source": {
-            "body": "\n  query testQuery {\n    getEntity {\n      id\n      name\n    }\n  }\n"
+            "body": "query testQuery{getEntity{id name}}"
         }
     }
 };

--- a/tests/fixtures/directives/output.js
+++ b/tests/fixtures/directives/output.js
@@ -52,9 +52,9 @@ const SIMPLE_DIRECTIVE = {
     ],
     "loc": {
         "start": 0,
-        "end": 67,
+        "end": 40,
         "source": {
-            "body": "\n  query testQuery {\n    getEntity {\n      id @directive\n    }\n  }\n"
+            "body": "query testQuery{getEntity{id@directive}}"
         }
     }
 };
@@ -133,9 +133,9 @@ const ARGUMENTS_DIRECTIVE = {
     ],
     "loc": {
         "start": 0,
-        "end": 93,
+        "end": 59,
         "source": {
-            "body": '\n  query testQuery {\n    getEntity {\n      id\n      name @directive(arg: "argVal")\n    }\n  }\n'
+            "body": 'query testQuery{getEntity{id name@directive(arg:"argVal")}}'
         }
     }
 };
@@ -237,9 +237,9 @@ const DIRECTIVES_SELECTION_SET = {
     ],
     "loc": {
         "start": 0,
-        "end": 127,
+        "end": 68,
         "source": {
-            "body": '\n  query testQuery {\n    getEntity {\n      id\n      user @directive(arg: "argVal") {\n        id\n        name\n      }\n    }\n  }\n'
+            "body": 'query testQuery{getEntity{id user@directive(arg:"argVal"){id name}}}'
         }
     }
 };

--- a/tests/fixtures/dynamicSegments/output.js
+++ b/tests/fixtures/dynamicSegments/output.js
@@ -76,9 +76,9 @@ const STATIC_QUERY = {
     ].concat(DYNAMIC_FRAGMENT.definitions),
     "loc": {
         "start": 0,
-        "end": 90,
+        "end": 42,
         "source": {
-            "body": "\n  query testQuery {\n    getEntity {\n      ... on LOL {\n        lol\n      }\n    }\n  }\n\n  \n"
+            "body": "query testQuery{getEntity{...on LOL{lol}}}"
         }
     }
 };

--- a/tests/fixtures/importSources/output.js
+++ b/tests/fixtures/importSources/output.js
@@ -38,9 +38,9 @@ const POSITIVE_CASE_1 = {
     ],
     "loc": {
         "start": 0,
-        "end": 39,
+        "end": 26,
         "source": {
-            "body": "\n  query testQuery {\n    getEntity\n  }\n"
+            "body": "query testQuery{getEntity}"
         }
     }
 };
@@ -75,9 +75,9 @@ const POSITIVE_CASE_2 = {
     ],
     "loc": {
         "start": 0,
-        "end": 39,
+        "end": 26,
         "source": {
-            "body": "\n  query testQuery {\n    getEntity\n  }\n"
+            "body": "query testQuery{getEntity}"
         }
     }
 };

--- a/tests/fixtures/selections/output.js
+++ b/tests/fixtures/selections/output.js
@@ -52,9 +52,9 @@ const NORMAL_SELECTION = {
     ],
     "loc": {
         "start": 0,
-        "end": 67,
+        "end": 35,
         "source": {
-            "body": "\n  query testQuery {\n    getEntity {\n      id\n      name\n    }\n  }\n"
+            "body": "query testQuery{getEntity{id name}}"
         }
     }
 };
@@ -170,9 +170,9 @@ const INLINE_FRAGMENT_SELECTION = {
     ],
     "loc": {
         "start": 0,
-        "end": 176,
+        "end": 84,
         "source": {
-            "body": "\n  query testQuery {\n    getEntity {\n      id\n      ... on User {\n        name\n        address\n      }\n      ... on Baby {\n        name\n        parentAddress\n      }\n    }\n  }\n"
+            "body": "query testQuery{getEntity{id...on User{name address}...on Baby{name parentAddress}}}"
         }
     }
 };
@@ -229,9 +229,9 @@ const USER_FRAGMENT = {
     ],
     "loc": {
         "start": 0,
-        "end": 67,
+        "end": 46,
         "source": {
-            "body": "\n  fragment UserFragment on User {\n    id\n    name\n    address\n  }\n"
+            "body": "fragment UserFragment on User{id name address}"
         }
     }
 };
@@ -288,9 +288,9 @@ const BABY_FRAGMENT = {
     ],
     "loc": {
         "start": 0,
-        "end": 73,
+        "end": 52,
         "source": {
-            "body": "\n  fragment BabyFragment on Baby {\n    id\n    name\n    parentAddress\n  }\n"
+            "body": "fragment BabyFragment on Baby{id name parentAddress}"
         }
     }
 };
@@ -345,9 +345,9 @@ const FRAGMENT_SPREAD_SELECTION = {
     ],
     "loc": {
         "start": 0,
-        "end": 91,
+        "end": 58,
         "source": {
-            "body": "\n  query testQuery {\n    getEntity {\n      ...UserFragment\n      ...BabyFragment\n    }\n  }\n"
+            "body": "query testQuery{getEntity{...UserFragment...BabyFragment}}"
         }
     }
 };

--- a/tests/fixtures/type/output.js
+++ b/tests/fixtures/type/output.js
@@ -52,9 +52,9 @@ const NAMED_TYPE = {
     ],
     "loc": {
         "start": 0,
-        "end": 63,
+        "end": 47,
         "source": {
-            "body": '\n  query testQuery($one: String = "apple") {\n    getEntity\n  }\n'
+            "body": 'query testQuery($one:String="apple"){getEntity}'
         }
     }
 };
@@ -110,9 +110,9 @@ const NAMED_TYPE_NOT_NULL = {
     ],
     "loc": {
         "start": 0,
-        "end": 54,
+        "end": 40,
         "source": {
-            "body": "\n  query testQuery($one: String!) {\n    getEntity\n  }\n"
+            "body": "query testQuery($one:String!){getEntity}"
         }
     }
 };
@@ -168,9 +168,9 @@ const LIST_TYPE = {
     ],
     "loc": {
         "start": 0,
-        "end": 55,
+        "end": 41,
         "source": {
-            "body": "\n  query testQuery($one: [String]) {\n    getEntity\n  }\n"
+            "body": "query testQuery($one:[String]){getEntity}"
         }
     }
 };
@@ -229,9 +229,9 @@ const LIST_TYPE_NOT_NULL = {
     ],
     "loc": {
         "start": 0,
-        "end": 56,
+        "end": 42,
         "source": {
-            "body": "\n  query testQuery($one: [String!]) {\n    getEntity\n  }\n"
+            "body": "query testQuery($one:[String!]){getEntity}"
         }
     }
 };

--- a/tests/fixtures/usage/defaultExport/output.js
+++ b/tests/fixtures/usage/defaultExport/output.js
@@ -106,9 +106,9 @@ export default {
     ],
     "loc": {
         "start": 0,
-        "end": 102,
+        "end": 61,
         "source": {
-            "body": "\n  query testQuery($a: String!) {\n    testQueryName(a: $a) @apple {\n      a\n      b\n      c\n    }\n  }\n"
+            "body": "query testQuery($a:String!){testQueryName(a:$a)@apple{a b c}}"
         }
     }
 };

--- a/tests/fixtures/usage/returnFromArrowFunction/output.js
+++ b/tests/fixtures/usage/returnFromArrowFunction/output.js
@@ -106,9 +106,9 @@ const getQuery = ()=>({
         ],
         "loc": {
             "start": 0,
-            "end": 102,
+            "end": 61,
             "source": {
-                "body": "\n  query testQuery($a: String!) {\n    testQueryName(a: $a) @apple {\n      a\n      b\n      c\n    }\n  }\n"
+                "body": "query testQuery($a:String!){testQueryName(a:$a)@apple{a b c}}"
             }
         }
     });

--- a/tests/fixtures/usage/returnFromFunctionExpression/output.js
+++ b/tests/fixtures/usage/returnFromFunctionExpression/output.js
@@ -107,9 +107,9 @@ const getQuery = function() {
         ],
         "loc": {
             "start": 0,
-            "end": 119,
+            "end": 118,
             "source": {
-                "body": "\n    query testQuery($a: String!) {\n      testQueryName(a: $a) @apple {\n        a\n        b\n        c\n      }\n    }\n  \n"
+                "body": "\n    query testQuery($a: String!) {\n      testQueryName(a: $a) @apple {\n        a\n        b\n        c\n      }\n    }\n  "
             }
         }
     };

--- a/tests/fixtures/usage/returnFromFunctionExpression/output.js
+++ b/tests/fixtures/usage/returnFromFunctionExpression/output.js
@@ -107,9 +107,9 @@ const getQuery = function() {
         ],
         "loc": {
             "start": 0,
-            "end": 118,
+            "end": 61,
             "source": {
-                "body": "\n    query testQuery($a: String!) {\n      testQueryName(a: $a) @apple {\n        a\n        b\n        c\n      }\n    }\n  "
+                "body": "query testQuery($a:String!){testQueryName(a:$a)@apple{a b c}}"
             }
         }
     };

--- a/tests/fixtures/values/output.js
+++ b/tests/fixtures/values/output.js
@@ -256,9 +256,9 @@ const ALL_BASIC_VALUES = {
     ],
     "loc": {
         "start": 0,
-        "end": 328,
+        "end": 222,
         "source": {
-            "body": '\n  query testQuery($var: String) {\n    getEntity(\n      var: $var\n      string: "Hello"\n      float: 2.2\n      int: 1\n      bool: true\n      nullVal: null\n      enumVal: TestEnumValue\n      objectValue: { a: "a", b: 1, c: { a: 1.1, b: [1, "a"] } }\n      list: ["string", 1.1, 1, true, null, TestEnumValue, { a: "a" }]\n    )\n  }\n'
+            "body": 'query testQuery($var:String){getEntity(var:$var string:"Hello" float:2.2 int:1 bool:true nullVal:null enumVal:TestEnumValue objectValue:{a:"a",b:1,c:{a:1.1,b:[1,"a"]}}list:["string",1.1,1,true,null,TestEnumValue,{a:"a"}])}'
         }
     }
 };

--- a/transform/src/parser/mod.rs
+++ b/transform/src/parser/mod.rs
@@ -8,7 +8,7 @@ use swc_ecma_ast::*;
 
 // modules
 mod nodes;
-mod utils;
+pub mod utils;
 
 // helpers
 use nodes::document::create_document;

--- a/transform/src/structs/mod.rs
+++ b/transform/src/structs/mod.rs
@@ -7,6 +7,7 @@ use swc_ecma_ast::Expr;
 pub struct GraphQLTagConfig {
     pub import_sources: Vec<String>,
     pub gql_tag_identifiers: Vec<String>,
+    pub strip: bool,
 }
 
 pub struct TransformVisitor {


### PR DESCRIPTION
This feature is in parity with strip config feature in `babel-plugin-graphql-tag`.
It passes striped gql string to parser, resulting in smaller AST in some cases + smaller memory footprint in generated code.