### PR TITLE
Add Checks for Operation Definition in GraphQL Query

### DIFF
--- a/tests/graphql_tag/definations/operation/unnamed_operation/input.js
+++ b/tests/graphql_tag/definations/operation/unnamed_operation/input.js
@@ -1,0 +1,3 @@
+import gql from 'graphql-tag';
+
+const foo = gql`{foo}`;

--- a/tests/graphql_tag/definations/operation/unnamed_operation/output.js
+++ b/tests/graphql_tag/definations/operation/unnamed_operation/output.js
@@ -1,0 +1,33 @@
+import gql from 'graphql-tag';
+const foo = {
+    "kind": "Document",
+    "definitions": [
+        {
+            "kind": "OperationDefinition",
+            "directives": [],
+            "variableDefinitions": [],
+            "operation": "query",
+            "selectionSet": {
+                "kind": "SelectionSet",
+                "selections": [
+                    {
+                        "kind": "Field",
+                        "name": {
+                            "kind": "Name",
+                            "value": "foo"
+                        },
+                        "arguments": [],
+                        "directives": []
+                    }
+                ]
+            }
+        }
+    ],
+    "loc": {
+        "start": 0,
+        "end": 5,
+        "source": {
+            "body": "{foo}"
+        }
+    }
+};

--- a/tests/graphql_tag/definations/operation/unnamed_operation/strip-output.js
+++ b/tests/graphql_tag/definations/operation/unnamed_operation/strip-output.js
@@ -1,0 +1,33 @@
+import gql from 'graphql-tag';
+const foo = {
+    "kind": "Document",
+    "definitions": [
+        {
+            "kind": "OperationDefinition",
+            "directives": [],
+            "variableDefinitions": [],
+            "operation": "query",
+            "selectionSet": {
+                "kind": "SelectionSet",
+                "selections": [
+                    {
+                        "kind": "Field",
+                        "name": {
+                            "kind": "Name",
+                            "value": "foo"
+                        },
+                        "arguments": [],
+                        "directives": []
+                    }
+                ]
+            }
+        }
+    ],
+    "loc": {
+        "start": 0,
+        "end": 5,
+        "source": {
+            "body": "{foo}"
+        }
+    }
+};

--- a/tests/graphql_tag/definations/operation/unnamed_query/input.js
+++ b/tests/graphql_tag/definations/operation/unnamed_query/input.js
@@ -1,0 +1,3 @@
+import gql from 'graphql-tag';
+
+const foo = gql`query($foo: String!) {foo1}`;

--- a/tests/graphql_tag/definations/operation/unnamed_query/output.js
+++ b/tests/graphql_tag/definations/operation/unnamed_query/output.js
@@ -1,0 +1,55 @@
+import gql from 'graphql-tag';
+const foo = {
+    "kind": "Document",
+    "definitions": [
+        {
+            "kind": "OperationDefinition",
+            "directives": [],
+            "variableDefinitions": [
+                {
+                    "kind": "VariableDefinition",
+                    "directives": [],
+                    "variable": {
+                        "kind": "Variable",
+                        "name": {
+                            "kind": "Name",
+                            "value": "foo"
+                        }
+                    },
+                    "type": {
+                        "kind": "NonNullType",
+                        "type": {
+                            "kind": "NamedType",
+                            "name": {
+                                "kind": "Name",
+                                "value": "String"
+                            }
+                        }
+                    }
+                }
+            ],
+            "operation": "query",
+            "selectionSet": {
+                "kind": "SelectionSet",
+                "selections": [
+                    {
+                        "kind": "Field",
+                        "name": {
+                            "kind": "Name",
+                            "value": "foo1"
+                        },
+                        "arguments": [],
+                        "directives": []
+                    }
+                ]
+            }
+        }
+    ],
+    "loc": {
+        "start": 0,
+        "end": 27,
+        "source": {
+            "body": "query($foo: String!) {foo1}"
+        }
+    }
+};

--- a/tests/graphql_tag/definations/operation/unnamed_query/strip-output.js
+++ b/tests/graphql_tag/definations/operation/unnamed_query/strip-output.js
@@ -1,0 +1,55 @@
+import gql from 'graphql-tag';
+const foo = {
+    "kind": "Document",
+    "definitions": [
+        {
+            "kind": "OperationDefinition",
+            "directives": [],
+            "variableDefinitions": [
+                {
+                    "kind": "VariableDefinition",
+                    "directives": [],
+                    "variable": {
+                        "kind": "Variable",
+                        "name": {
+                            "kind": "Name",
+                            "value": "foo"
+                        }
+                    },
+                    "type": {
+                        "kind": "NonNullType",
+                        "type": {
+                            "kind": "NamedType",
+                            "name": {
+                                "kind": "Name",
+                                "value": "String"
+                            }
+                        }
+                    }
+                }
+            ],
+            "operation": "query",
+            "selectionSet": {
+                "kind": "SelectionSet",
+                "selections": [
+                    {
+                        "kind": "Field",
+                        "name": {
+                            "kind": "Name",
+                            "value": "foo1"
+                        },
+                        "arguments": [],
+                        "directives": []
+                    }
+                ]
+            }
+        }
+    ],
+    "loc": {
+        "start": 0,
+        "end": 25,
+        "source": {
+            "body": "query($foo:String!){foo1}"
+        }
+    }
+};

--- a/transforms/graphql_tag/src/parser/nodes/definitions/mod.rs
+++ b/transforms/graphql_tag/src/parser/nodes/definitions/mod.rs
@@ -42,6 +42,15 @@ pub fn create_definition(definition: Definition, span: Span) -> Option<ExprOrSpr
 
 pub fn create_definitions(definitions: CstChildren<Definition>, span: Span) -> Expr {
     let mut all_definitions = vec![];
+    let definitions_length = definitions.clone().count();
+
+    if definitions_length > 1 && definitions.clone().filter(|def| match def {
+        Definition::OperationDefinition(_) => true,
+        _ => false
+    }).any(|def| def.name() == None) {
+        panic!("GraphQL query must have name.");
+    }
+
     for def in definitions {
         all_definitions.push(create_definition(def, span));
     }

--- a/transforms/graphql_tag/src/parser/nodes/definitions/mod.rs
+++ b/transforms/graphql_tag/src/parser/nodes/definitions/mod.rs
@@ -11,8 +11,12 @@ mod operation;
 use fragment::create_fragment_definition;
 use operation::create_operation_definition;
 
-pub fn create_definition(definition: Definition, span: Span, is_multiple_definitions: bool) -> Option<ExprOrSpread> {
-    if is_multiple_definitions {
+pub fn create_definition(
+    definition: Definition,
+    span: Span,
+    assert_definition_name: bool,
+) -> Option<ExprOrSpread> {
+    if assert_definition_name {
         definition.name().expect("GraphQL query must have name.");
     }
     let def_expr = match definition {

--- a/transforms/graphql_tag/src/parser/nodes/definitions/operation.rs
+++ b/transforms/graphql_tag/src/parser/nodes/definitions/operation.rs
@@ -14,10 +14,7 @@ use crate::parser::{
 
 pub fn create_operation_definition(definition: OperationDefinition, span: Span) -> Box<Expr> {
     let kind = get_key_value_node("kind".into(), "OperationDefinition".into());
-    let name = get_key_value_node(
-        "name".into(),
-        create_name(definition.name().unwrap().text().as_str().into(), span),
-    );
+    
     let variable_definitions = get_key_value_node(
         "variableDefinitions".into(),
         create_variable_definitions(definition.variable_definitions(), span),
@@ -34,8 +31,15 @@ pub fn create_operation_definition(definition: OperationDefinition, span: Span) 
 
     let mut opr_def = ObjectLit {
         span,
-        props: vec![kind, name, directives, variable_definitions, operation],
+        props: vec![kind, directives, variable_definitions, operation],
     };
+
+    if definition.name() != None {
+        opr_def.props.insert(1,get_key_value_node(
+            "name".into(),
+            create_name(definition.name().unwrap().text().as_str().into(), span),
+        ));
+    }
 
     if definition.selection_set().is_some() {
         let selection_set = get_key_value_node(

--- a/transforms/graphql_tag/src/parser/nodes/definitions/operation.rs
+++ b/transforms/graphql_tag/src/parser/nodes/definitions/operation.rs
@@ -14,7 +14,7 @@ use crate::parser::{
 
 pub fn create_operation_definition(definition: OperationDefinition, span: Span) -> Box<Expr> {
     let kind = get_key_value_node("kind".into(), "OperationDefinition".into());
-    
+
     let variable_definitions = get_key_value_node(
         "variableDefinitions".into(),
         create_variable_definitions(definition.variable_definitions(), span),
@@ -35,10 +35,13 @@ pub fn create_operation_definition(definition: OperationDefinition, span: Span) 
     };
 
     if definition.name().is_some() {
-        opr_def.props.insert(1,get_key_value_node(
-            "name".into(),
-            create_name(definition.name().unwrap().text().as_str().into(), span),
-        ));
+        opr_def.props.insert(
+            1,
+            get_key_value_node(
+                "name".into(),
+                create_name(definition.name().unwrap().text().as_str().into(), span),
+            ),
+        );
     }
 
     if definition.selection_set().is_some() {

--- a/transforms/graphql_tag/src/parser/nodes/definitions/operation.rs
+++ b/transforms/graphql_tag/src/parser/nodes/definitions/operation.rs
@@ -34,7 +34,7 @@ pub fn create_operation_definition(definition: OperationDefinition, span: Span) 
         props: vec![kind, directives, variable_definitions, operation],
     };
 
-    if definition.name() != None {
+    if definition.name().is_some() {
         opr_def.props.insert(1,get_key_value_node(
             "name".into(),
             create_name(definition.name().unwrap().text().as_str().into(), span),

--- a/transforms/graphql_tag/src/parser/utils.rs
+++ b/transforms/graphql_tag/src/parser/utils.rs
@@ -10,10 +10,10 @@ pub fn get_key_value_node(key: String, value: Expr) -> PropOrSpread {
 }
 
 pub fn get_operation_token(operation_type: Option<OperationType>) -> String {
-    if operation_type.is_none() { 
+    if operation_type.is_none() {
         return "query".into();
     }
-    
+
     let opr_token = operation_type.unwrap();
 
     if opr_token.query_token().is_some() {

--- a/transforms/graphql_tag/src/parser/utils.rs
+++ b/transforms/graphql_tag/src/parser/utils.rs
@@ -10,7 +10,7 @@ pub fn get_key_value_node(key: String, value: Expr) -> PropOrSpread {
 }
 
 pub fn get_operation_token(operation_type: Option<OperationType>) -> String {
-    if operation_type == None { 
+    if operation_type.is_none() { 
         return "query".into();
     }
     

--- a/transforms/graphql_tag/src/parser/utils.rs
+++ b/transforms/graphql_tag/src/parser/utils.rs
@@ -10,6 +10,10 @@ pub fn get_key_value_node(key: String, value: Expr) -> PropOrSpread {
 }
 
 pub fn get_operation_token(operation_type: Option<OperationType>) -> String {
+    if operation_type == None { 
+        return "query".into();
+    }
+    
     let opr_token = operation_type.unwrap();
 
     if opr_token.query_token().is_some() {


### PR DESCRIPTION
This PR addresses missing checks for operation definitions in GraphQL queries.

Changes include:

1. Added condition to check if definition name is present then insert it into the props vector.
2. For cases where no operation type is provided, it defaults to "query".
3. Added logic to create all_definitions vector, and a check for presence of more than one definition. In case where a name is absent for any of these definitions, an appropriate error is thrown.

Lay the groundwork for further validation checks in GraphQL query processing based on the behavior of 'gajus/babel-plugin-graphql-tag' project.

While extensive testing has been done locally, it has not been fully covered by automated tests due to Rust experience constraints. Specifically, error/panic scenarios demand more test coverage.

This effort has mimicked necessary logic from an existing solution found at https://github.com/gajus/babel-plugin-graphql-tag/blob/master/test/fixtures/graphql-tag. The current changes seek to ensure similar, comprehensive validation checks in Rust implementation.
#21 